### PR TITLE
fix(cookiecutter): fix new package name template

### DIFF
--- a/cookiecutter.config.js
+++ b/cookiecutter.config.js
@@ -6,11 +6,11 @@ module.exports = [
     fields: [
       {
         templateVariable: "PACKAGE_NAME",
-        question: "What is the package's name?",
+        question: "What is the package's name? \n Package names MUST contain the following particles (particles in parentheses MAY be included, parts in angular brackets MUST be included only if applicable):\n library-domain(-subdomains)[-organization][-product] \n",
         errorMessage:
-          "Package name must be in snake_case and be lower case. Example: my_package",
+          "Package name must be in kebab-case and be lower case. Example: ecc-client-ga4gh-service-registry",
         isValid: function (value) {
-          return !!value.match(/^[a-z0-9]+(_[a-z0-9]+)*$/);
+          return !!value.match(/^[a-z0-9]+(-[a-z0-9]+)*$/);
         },
       },
       {


### PR DESCRIPTION
New package names are recommended to be in kebab-case, altered cookiecutter config to accommodate for kebab-case instead of previously defined snake_case.

## Description

According to the naming convention, `Package names MUST contain the following particles (particles in parentheses MAY be included, parts in angular brackets MUST be included only if applicable): library-domain(-subdomains)[-organization][-product]` , the name of the packages needs to be in kebab case but the cookiecutter config only allowed snake_case naming convention, This PR changes the package naming convention to the recommended practice. 

## Checklist

> Please go through the following checklist to ensure that your change is ready
> for review. Please do not forget to double check the list after you have
> modified your PR, e.g., if you have added commits to address reviewer
> comments or to fix failing automated checks. Please check items also if they
> do not apply to your change, e.g., if your change does not require an update
> of the user-facing documentation, then still check the box. Generally, PRs
> are only reviewed when all boxes are ticked off and all automated checks pass
> (use the comment section below if you believe that your PR is ready to be
> merged even though not all boxes were ticked off).

- [x] My code follows the [contributing guidelines][contributing] of this
      project, including, in particular, with regard to any style guidelines
- [x] The title of my PR complies with the [Conventional Commits
      specification][conventional-commits]; in particular, it clearly indicates
      that a change is a breaking change
- [x] I am aware that all my commits will be squashed into a single commit,
      using the PR title as the commit message.
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have updated the user-facing documentation to describe any new or
      changed behavior
- [ ] I have added type annotations for all function/class/method interfaces
      or updated existing ones
- [ ] I have provided [JSDoc][jsdoc] block tags for all
      functions/classes/methods or updated existing ones
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature
      works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not reduced the existing code coverage
- [ ] I have asked the [@all-contributors bot][all-contributors-bot] to
      acknowledge my contributions by commenting on this PR with a request of
      the form `@all-contributors please add @YOUR_GH_HANDLE for TYPE_1,
    TYPE_2, ...`, where `TYPE_1` etc. refer to [contribution types supported
      by the All Contributors Specification][all-contributors-types] OR I do
      not want my contributions to be acknowledged

## Comments

Above unchecked boxes are not required for this PR

[all-contributors-bot]: https://allcontributors.org/docs/en/bot/overview
[all-contributors-types]: https://allcontributors.org/docs/en/emoji-key
[contributing]: CONTRIBUTING.md
[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[jsdoc]: https://jsdoc.app/index.html
