### PR TITLE
fix: replace lint with lint:fix in precommit commands

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,7 +2,7 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 # run the lint command
-npm run lint
+npm run lint:fix
 
 # run the test command
 npm run test


### PR DESCRIPTION
If the linter is already going through the whole repo it makes more sense to fix fixable lint error instead of just throwing error this will significantly reduce commit time. This will not produce bad commits as for the errors which couldn;t be fixed, eslint will throw an error.