### PR TITLE
build(ecc-utils-design): implements code splitting and other improvements

### DIFF
--- a/apps/documentation/docs/design/components/form.md
+++ b/apps/documentation/docs/design/components/form.md
@@ -10,7 +10,7 @@ This component is used to render a form with the given fields.
 ::: code-group
 
 ```js [HTML]
-import "@elixir-cloud/design";
+import "@elixir-cloud/design/dist/form/index.js";
 
 const fields = [...];
 
@@ -34,7 +34,7 @@ const fields = [...];
 ## Importing
 
 ```js [HTML]
-import "@elixir-cloud/design";
+import "@elixir-cloud/design/dist/form/index.js";
 ```
 
 ## Properties
@@ -104,7 +104,7 @@ This property is used to render the fields in the form. Fields can be passed as 
 ::: code-group
 
 ```js [HTML]
-import "@elixir-cloud/design";
+import "@elixir-cloud/design/dist/form/index.js";
 
 
 const fields = [
@@ -215,7 +215,7 @@ const fields = [
 ::: code-group
 
 ```js [HTML]
-import "@elixir-cloud/design";
+import "@elixir-cloud/design/dist/form/index.js";
 
 const fields = [
   {
@@ -269,7 +269,7 @@ const fields = [
 ::: code-group
 
 ```js [HTML]
-import "@elixir-cloud/design";
+import "@elixir-cloud/design/dist/form/index.js";
 
 
 const fields = [

--- a/packages/ecc-utils-design/package.json
+++ b/packages/ecc-utils-design/package.json
@@ -5,7 +5,8 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./dist/index.js"
+    ".": "./dist/index.js",
+    "./dist/*": "./dist/*"
   },
   "type": "module",
   "version": "0.0.1",
@@ -14,8 +15,8 @@
   "repository": "",
   "scripts": {
     "analyze": "cem analyze --litelement",
-    "build": "tsup src/index.ts --format cjs,esm --dts",
-    "dev": "npm run build && concurrently -k -r \"npm run build -- --watch\" \"wds\"",
+    "build": "node ./scripts/build.js",
+    "dev": "concurrently -r \"npm run build --watch\" \"wds\"",
     "test": "wtr --coverage",
     "test:watch": "wtr --watch",
     "storybook": "npm run build && npm run analyze -- --exclude dist && concurrently -k -r \"npm run build -- --watch\" \"wds -c .storybook/server.mjs\"",
@@ -33,10 +34,13 @@
     "@web/dev-server-esbuild": "^0.4.3",
     "@web/dev-server-storybook": "^1.0.2",
     "@web/test-runner": "^0.17.0",
+    "commander": "^11.1.0",
     "concurrently": "^8.2.1",
+    "esbuild": "0.18.20",
     "eslint": "^8.41.0",
     "eslint-config-elixir": "*",
     "eslint-plugin-prettier": "^4.2.1",
+    "globby": "^14.0.0",
     "tslib": "^2.6.2",
     "tsup": "^7.2.0",
     "typescript": "^5.0.4"

--- a/packages/ecc-utils-design/scripts/build.js
+++ b/packages/ecc-utils-design/scripts/build.js
@@ -1,10 +1,10 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
-import { globby } from 'globby';
-import * as tsup from 'tsup';
-import { program } from 'commander';
+import { globby } from "globby";
+import * as tsup from "tsup";
+import { program } from "commander";
 
-program.option('-w --watch');
+program.option("-w --watch");
 program.parse();
 const options = program.opts();
 
@@ -13,14 +13,14 @@ const options = program.opts();
 // write script for react builds
 
 const config = {
-  format: 'esm',
-  target: 'es2017',
-  entry: [...(await globby('./src/components/**/!(*.(style|test)).ts'))],
+  format: "esm",
+  target: "es2017",
+  entry: [...(await globby("./src/components/**/!(*.(style|test)).ts"))],
   splitting: true,
   treeshake: true,
   bundle: true,
-  outDir: 'dist',
-  clean: 'true',
+  outDir: "dist",
+  clean: "true",
   dts: true,
   watch: options.watch,
 };

--- a/packages/ecc-utils-design/scripts/build.js
+++ b/packages/ecc-utils-design/scripts/build.js
@@ -1,0 +1,30 @@
+/* eslint-disable import/no-extraneous-dependencies */
+
+import { globby } from 'globby';
+import * as tsup from 'tsup';
+import { program } from 'commander';
+
+program.option('-w --watch');
+program.parse();
+const options = program.opts();
+
+// to do:
+// write cdn config
+// write script for react builds
+
+const config = {
+  format: 'esm',
+  target: 'es2017',
+  entry: [...(await globby('./src/components/**/!(*.(style|test)).ts'))],
+  splitting: true,
+  treeshake: true,
+  bundle: true,
+  outDir: 'dist',
+  clean: 'true',
+  dts: true,
+  watch: options.watch,
+};
+
+await tsup.build({
+  ...config,
+});

--- a/packages/ecc-utils-design/src/components/form/form.ts
+++ b/packages/ecc-utils-design/src/components/form/form.ts
@@ -36,7 +36,7 @@ interface Field {
   children?: Array<Field>;
 }
 
-export class Form extends LitElement {
+export default class Form extends LitElement {
   static styles = [
     sholelaceLightStyles,
     hostStyles,

--- a/packages/ecc-utils-design/src/components/form/index.ts
+++ b/packages/ecc-utils-design/src/components/form/index.ts
@@ -1,3 +1,12 @@
-import { Form } from "./form.js";
+import Form from "./form.js";
+
+export * from "./form.js";
+export default Form;
 
 window.customElements.define("ecc-utils-design-form", Form);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ecc-utils-design-form": Form;
+  }
+}

--- a/packages/ecc-utils-design/src/components/index.ts
+++ b/packages/ecc-utils-design/src/components/index.ts
@@ -1,1 +1,1 @@
-import "./form/index.js";
+export { default as Form } from "./form/index.js";


### PR DESCRIPTION

## Description
This solves part of the problem of improving the bundling by implementing code splitting, which reduces the size of the packages and allows packages using the design packages to implement tree shaking. It also ensures that the declaration files are properly generated to add type and intellisense support.

Fixes #138 

## Checklist
<!-- Please go through the following checklist to ensure that your change is ready for review. -->

- [ ] My code follows the [contributing guidelines][contributing] of this project.
- [ ] I am aware that all my commits will be squashed into a single commit, using the PR title as the commit message.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have updated the user-facing documentation to describe any new or changed behavior.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have not reduced the existing code coverage.

## Comments
<!-- If there are unchecked boxes in the list above, but you would still like your PR to be reviewed or considered for merging, please describe here why boxes were not checked. -->

[contributing]: CONTRIBUTING.md
