### PR TITLE
fix: required asterisk

### DIFF
--- a/packages/ecc-client-lit-ga4gh-tes/src/components/tes-create-run/create-run.ts
+++ b/packages/ecc-client-lit-ga4gh-tes/src/components/tes-create-run/create-run.ts
@@ -35,6 +35,9 @@ export class TESCreateRun extends LitElement {
       key: "executors",
       label: "Executors",
       type: "group",
+      fieldOptions: {
+        required: true,
+      },
       groupOptions: {
         collapsible: true,
       },
@@ -43,9 +46,6 @@ export class TESCreateRun extends LitElement {
           key: "executors",
           label: "",
           type: "array",
-          fieldOptions: {
-            required: true,
-          },
           arrayOptions: {
             defaultInstances: 1,
             min: 1,
@@ -65,11 +65,8 @@ export class TESCreateRun extends LitElement {
               children: [
                 {
                   key: "command",
-                  label: "Command",
+                  label: "",
                   type: "text",
-                  fieldOptions: {
-                    required: true,
-                  },
                 },
               ],
             },

--- a/packages/ecc-utils-design/src/components/form/form.ts
+++ b/packages/ecc-utils-design/src/components/form/form.ts
@@ -252,7 +252,7 @@ export default class EccUtilsDesignForm extends LitElement {
           class="array-header"
         >
           <label part="${label} ${arrayLabel}" class="array-label">
-            ${field.label}
+            ${field.label} ${field.fieldOptions?.required ? "*" : ""}
           </label>
           <sl-button
             variant="text"
@@ -352,7 +352,9 @@ export default class EccUtilsDesignForm extends LitElement {
     return html` <div class="group-container">
       ${field.groupOptions?.collapsible
         ? html` <sl-details
-            summary=${field.label}
+            summary=${`${field.label} ${
+              field.fieldOptions?.required ? "*" : ""
+            }`}
             exportparts="base: ${groupBase}, header: ${groupHeader}, header: ${header}, summary: ${label}, summary: ${groupLabel}, summary-icon: ${groupToggleIcon}, content: ${groupContent}"
           >
             ${renderChildren()}


### PR DESCRIPTION
## Description
Added asterisks for required groups, like executors.
Remove the label for each command in the commands array as it looked redundant. 
![image](https://github.com/elixir-cloud-aai/cloud-components/assets/100477031/4368a1ea-668f-4346-b77f-870af00caf66)

Fixes #176 

## Checklist
<!-- Please go through the following checklist to ensure that your change is ready for review. -->

- [x] My code follows the [contributing guidelines][contributing] of this project.
- [x] I am aware that all my commits will be squashed into a single commit, using the PR title as the commit message.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code in hard-to-understand areas.
- [x] I have updated the user-facing documentation to describe any new or changed behavior.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have not reduced the existing code coverage.

## Comments
<!-- If there are unchecked boxes in the list above, but you would still like your PR to be reviewed or considered for merging, please describe here why boxes were not checked. -->

[contributing]: CONTRIBUTING.md
