### PR TITLE
fix: prevent re-fetch runs

### DIFF
--- a/packages/ecc-client-lit-ga4gh-tes/package.json
+++ b/packages/ecc-client-lit-ga4gh-tes/package.json
@@ -9,10 +9,7 @@
   "types": "./dist/index.d.ts",
   "componentsPrefix": "ecc-client-lit-ga4gh-tes-",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    },
+    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
     "./dist/custom-elements.json": "./dist/custom-elements.json",
     "./dist/index.js": "./dist/index.js",
     "./dist/components/*": "./dist/components/*",
@@ -33,10 +30,7 @@
     "lint:fix": "npm run lint -- --fix",
     "prepublish": "npm run build"
   },
-  "dependencies": {
-    "@elixir-cloud/design": "*",
-    "lit": "^2.8.0"
-  },
+  "dependencies": { "@elixir-cloud/design": "*", "lit": "^2.8.0" },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.4.17",
     "@open-wc/eslint-config": "^9.2.1",

--- a/packages/ecc-client-lit-ga4gh-tes/src/components/runs/runs.ts
+++ b/packages/ecc-client-lit-ga4gh-tes/src/components/runs/runs.ts
@@ -440,8 +440,11 @@ export default class ECCClientGa4ghTesRuns extends LitElement {
         @ecc-utils-page-change=${(event: CustomEvent) => {
           this._fetchData(event.detail.page);
         }}
-        @ecc-utils-expand=${(event: CustomEvent) =>
-          this._handleExpandItem(event)}
+        @ecc-utils-expand=${(event: CustomEvent) => {
+          if (!this.cache.has(event.detail.key)) {
+            this._handleExpandItem(event);
+          }
+        }}
       >
       </ecc-utils-design-collection>
     `;

--- a/packages/ecc-client-lit-ga4gh-tes/src/components/runs/runs.ts
+++ b/packages/ecc-client-lit-ga4gh-tes/src/components/runs/runs.ts
@@ -356,14 +356,14 @@ export default class ECCClientGa4ghTesRuns extends LitElement {
     }
 
     const { key } = detail;
-    const children = target.querySelectorAll(`[slot="${key}"]`);
-    const runData = await fetchTask(this.baseURL, detail.key);
+    const children = target!.shadowRoot?.querySelectorAll(
+      `slot[name='${key}']`
+    );
 
-    if (this.cache.has(key)) return;
-    // Cache the run data if not present
+    const runData = await fetchTask(this.baseURL, detail.key);
     this.cache.set(key, runData);
 
-    if (children) {
+    if (children?.length) {
       try {
         const child = document.createElement("div");
         child.setAttribute("slot", key);

--- a/packages/ecc-client-lit-ga4gh-wes/src/components/runs/runs.ts
+++ b/packages/ecc-client-lit-ga4gh-wes/src/components/runs/runs.ts
@@ -428,8 +428,11 @@ export default class ECCClientGa4ghWesRuns extends LitElement {
         @ecc-utils-page-change=${(event: CustomEvent) => {
           this._fetchData(event.detail.page);
         }}
-        @ecc-utils-expand=${(event: CustomEvent) =>
-          this._handleExpandItem(event)}
+        @ecc-utils-expand=${(event: CustomEvent) => {
+          if (!this.cache.has(event.detail.key)) {
+            this._handleExpandItem(event);
+          }
+        }}
       >
       </ecc-utils-design-collection>
     `;

--- a/packages/ecc-client-lit-ga4gh-wes/src/components/runs/runs.ts
+++ b/packages/ecc-client-lit-ga4gh-wes/src/components/runs/runs.ts
@@ -343,14 +343,13 @@ export default class ECCClientGa4ghWesRuns extends LitElement {
     }
 
     const { key } = detail;
-    const children = target.querySelectorAll(`[slot="${key}"]`);
+    const children = target!.shadowRoot?.querySelectorAll(
+      `slot[name='${key}']`
+    );
     const runData = await fetchWorkflow(this.baseURL, detail.key);
-
-    if (this.cache.has(key)) return;
-    // Cache the run data if not present
     this.cache.set(key, runData);
 
-    if (children) {
+    if (children?.length) {
       try {
         const child = document.createElement("div");
         child.setAttribute("slot", key);


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and the relevant issue(s) it resolves, if any (otherwise delete that line). -->

Fixes #242 
- This commit introduces optimizations to avoid re-fetching of runs on accordian click.
- Previously, the event handler `handleExpandItem` was triggered on each accordian click. 
- With this change, a cache check has been implemented determining whether the `run` or an accordian within a run,being expanded already exists in the cache(done by checking the `key` of the run in the cache).
- If the run is not found in the cache, the `handleExpandItem` function is executed, thereby avoiding unnecessary network calls on subsequent accordian clicks. 
- This optimization also handles clicking an accordian inside the runs accordian.
## Checklist
<!-- Please go through the following checklist to ensure that your change is ready for review. -->

- [x] My code follows the [contributing guidelines][contributing] of this project.
- [X] I am aware that all my commits will be squashed into a single commit, using the PR title as the commit message.
- [X] I have performed a self-review of my own code.
- [X] My changes generate no new warnings.
- [X] I have not reduced the existing code coverage.


[contributing]: CONTRIBUTING.md
