### PR TITLE
refactor(tes): remove filter by status dead code

### DIFF
--- a/packages/ecc-client-ga4gh-tes/src/components/tes-runs/definition/tesRuns.template.ts
+++ b/packages/ecc-client-ga4gh-tes/src/components/tes-runs/definition/tesRuns.template.ts
@@ -8,7 +8,7 @@ import {
   fastTextField,
 } from '@microsoft/fast-components';
 import { html, repeat, when } from '@microsoft/fast-element';
-import TESRuns, { stateOption } from './tesRuns.js';
+import TESRuns from './tesRuns.js';
 import { TESRun } from '../../tes-run/index.js';
 
 provideFASTDesignSystem().register(
@@ -29,16 +29,6 @@ const template = html<TESRuns>`
         @input=${(x, c) => x.handleNameInput(c.event)}
       >
       </fast-text-field>
-      <fast-select
-        :value=${(x) => x.stateInput}
-        @input=${(x, c) => x.handleStateInput(c.event)}
-      >
-        <fast-option value="ALL">ALL</fast-option>
-        ${repeat(
-          () => stateOption,
-          html`<fast-option value=${(x) => x}>${(x) => x}</fast-option>`
-        )}
-      </fast-select>
     </div>
     <div class="list">
       <fast-accordion>
@@ -113,7 +103,9 @@ const template = html<TESRuns>`
           >
           <fast-button
             appearance="neutral"
-            ?disabled=${(x) => x.tokens[x.pageNumber + 1] === undefined}
+            ?disabled=${(x) =>
+              x.tokens[x.pageNumber + 1] === undefined ||
+              Object.entries(x.data).length === 0}
             @click=${(x) => x.handleNext()}
           >
             <svg

--- a/packages/ecc-client-ga4gh-tes/src/components/tes-runs/definition/tesRuns.ts
+++ b/packages/ecc-client-ga4gh-tes/src/components/tes-runs/definition/tesRuns.ts
@@ -56,8 +56,6 @@ export default class TESRuns extends FASTElement {
   // Seach input for name_prefix filter
   @observable searchInput = '';
 
-  @observable stateInput = 'ALL';
-
   @observable unfilterdData: Data = {
     tasks: [],
     next_page_token: '',
@@ -102,9 +100,6 @@ export default class TESRuns extends FASTElement {
 
   // Cache next click
   handleNext = async () => {
-    // Reset the state filter
-    this.stateInput = 'ALL';
-
     // Calculate the next page
     const nextPageNumber = this.pageNumber + 1;
     this.pageNumber = nextPageNumber; // Increment the pageNumber
@@ -121,7 +116,6 @@ export default class TESRuns extends FASTElement {
 
   // Handle prev click
   handlePrev = async () => {
-    this.stateInput = 'ALL';
     const prevPageNumber = this.pageNumber - 1;
     const prevPageToken = this.tokens[prevPageNumber];
     await this.fetchData(prevPageToken, this.searchInput);
@@ -136,17 +130,5 @@ export default class TESRuns extends FASTElement {
 
     // Fetch new data
     this.fetchData('', this.searchInput);
-  }
-
-  handleStateInput(event: Event) {
-    this.stateInput = (event.target as HTMLInputElement).value;
-
-    // Filter data on current page based on the filter input
-    if (this.stateInput === 'ALL') this.data = this.unfilterdData.tasks;
-    else {
-      this.data = this.unfilterdData.tasks.filter(
-        (task) => task.state === this.stateInput
-      );
-    }
   }
 }

--- a/packages/ecc-client-lit-ga4gh-tes/src/components/runs/runs.ts
+++ b/packages/ecc-client-lit-ga4gh-tes/src/components/runs/runs.ts
@@ -45,7 +45,7 @@ export interface ItemProp {
 
 export interface FilterProp {
   key: string;
-  type: "search" | "select";
+  type: "search";
   options?: string[];
   selectConfig?: {
     multiple?: boolean;
@@ -80,7 +80,6 @@ export default class ECCClientGa4ghTesRuns extends LitElement {
   @property({ type: String }) private baseURL =
     "https://protes.rahtiapp.fi/ga4gh/tes/v1";
 
-  @property({ type: Boolean }) private filter = true;
   @property({ type: Boolean }) private search = true;
   @property({ type: Array }) private fields: Array<Field> = [
     {
@@ -215,27 +214,6 @@ export default class ECCClientGa4ghTesRuns extends LitElement {
       type: "search",
       placeholder: "Search by prefix",
     },
-    {
-      key: "tag",
-      type: "select",
-      options: [
-        "UNKNOWN",
-        "QUEUED",
-        "INITIALIZING",
-        "RUNNING",
-        "PAUSED",
-        "COMPLETE",
-        "EXECUTOR_ERROR",
-        "SYSTEM_ERROR",
-        "CANCELED",
-        "PREEMPTED",
-        "CANCELING",
-      ],
-      placeholder: "Filter by status",
-      selectConfig: {
-        multiple: false,
-      },
-    },
   ];
 
   @state() private items: ItemProp[] = [];
@@ -268,8 +246,8 @@ export default class ECCClientGa4ghTesRuns extends LitElement {
       this._fetchData(1);
     }
 
-    // Handle filter render
-    if (changedProperties.has("filter") || changedProperties.has("search")) {
+    // Handle search by prefix render
+    if (changedProperties.has("search")) {
       this.filters = this.getUpdatedFilters();
     }
   }
@@ -278,11 +256,6 @@ export default class ECCClientGa4ghTesRuns extends LitElement {
     let updatedFilters = [...this.filters];
 
     // Modify the array based on the conditions
-    if (!this.filter) {
-      updatedFilters = updatedFilters.filter(
-        (filter) => filter.type !== "select"
-      );
-    }
     if (!this.search) {
       updatedFilters = updatedFilters.filter(
         (filter) => filter.type !== "search"


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and the relevant issue(s) it resolves, if any (otherwise delete that line). -->

Fixes #270 

- This commit refactors the `ecc-client-lit-ga4gh-tes-runs`
- Removed the dead client-side code logic for `filter by status`. 
- Removed the `handleStateInput()` function responsible for displaying tasks based on their status.
- Additionally, updated the `tesRuns` template removing the select by run status drop-down option.

## Checklist
<!-- Please go through the following checklist to ensure that your change is ready for review. -->

- [X] My code follows the [contributing guidelines][contributing] of this project.
- [X] I am aware that all my commits will be squashed into a single commit, using the PR title as the commit message.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code in hard-to-understand areas.
- [X] My changes generate no new warnings.
- [X] I have not reduced the existing code coverage.


[contributing]: CONTRIBUTING.md
