### PR TITLE
Fix: stop modifying packagejson

### DIFF
--- a/packages/ecc-utils-design/package.json
+++ b/packages/ecc-utils-design/package.json
@@ -7,7 +7,10 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" },
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
     "./dist/custom-elements.json": "./dist/custom-elements.json",
     "./dist/index.js": "./dist/index.js",
     "./dist/components/*": "./dist/components/*",
@@ -21,7 +24,12 @@
     "url": "https://github.com/elixir-cloud-aai/cloud-components.git"
   },
   "customElements": "dist/custom-elements.json",
-  "files": ["dist", "README.md", "package.json", "LICENSE"],
+  "files": [
+    "dist",
+    "README.md",
+    "package.json",
+    "LICENSE"
+  ],
   "scripts": {
     "analyze": "cem analyze --litelement",
     "build": "node ../../scripts/build.js -p ecc-utils-design-",

--- a/turbo/generators/template-package/package.json.hbs
+++ b/turbo/generators/template-package/package.json.hbs
@@ -27,6 +27,11 @@
     "eslint": "^8.41.0",
     "eslint-config-elixir": "*",
     "eslint-plugin-prettier": "^4.2.1",
-    "typescript": "*"
+    "typescript": "*",
+    "@lit/react": "*",
+    "react": "*",
+    "commander": "*",
+    "custom-element-jet-brains-integration": "*",
+    "custom-element-vs-code-integration": "*"
   }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and the relevant issue(s) it resolves, if any (otherwise delete that line). -->
This PR stops the build scripts from modifying the packagejson. Instead it tells the user the specific dependency that is missing and to install it. It also adds the necessary dependencies to the templates.


## Checklist
<!-- Please go through the following checklist to ensure that your change is ready for review. -->

- [ ] My code follows the [contributing guidelines][contributing] of this project.
- [ ] I am aware that all my commits will be squashed into a single commit, using the PR title as the commit message.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have updated the user-facing documentation to describe any new or changed behavior.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have not reduced the existing code coverage.

## Comments
<!-- If there are unchecked boxes in the list above, but you would still like your PR to be reviewed or considered for merging, please describe here why boxes were not checked. -->

[contributing]: CONTRIBUTING.md
