### PR TITLE
Added readonly type field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26662,7 +26662,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@elixir-cloud/design": "^0.1.1",
+        "@elixir-cloud/design": "^1.0.0",
         "lit": "^3.2.0"
       },
       "devDependencies": {
@@ -27075,7 +27075,7 @@
     },
     "packages/ecc-client-ga4gh-tes": {
       "name": "@elixir-cloud/tes",
-      "version": "0.1.1",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@elixir-cloud/design": "*",
@@ -28005,7 +28005,7 @@
     },
     "packages/ecc-client-ga4gh-wes": {
       "name": "@elixir-cloud/wes",
-      "version": "0.1.1",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@elixir-cloud/design": "*",
@@ -28882,7 +28882,7 @@
     },
     "packages/ecc-utils-design": {
       "name": "@elixir-cloud/design",
-      "version": "0.1.1",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@anurag_gupta/tus-js-client": "^4.2.10",

--- a/packages/ecc-client-elixir-ro-crate/src/components/about/about.ts
+++ b/packages/ecc-client-elixir-ro-crate/src/components/about/about.ts
@@ -118,6 +118,32 @@ export default class ECCClientRoCrateAbout extends LitElement {
     },
 
     {
+      key: "@type",
+      label: "@type",
+      type: "array",
+      fieldOptions: {
+        tooltip: "The type of the entity.",
+      },
+      arrayOptions: {
+        defaultInstances: 1,
+        max: 1,
+      },
+      children: [
+        {
+          key: "Type",
+          label: "Select",
+          type: "text",
+          fieldOptions: {
+            required: true,
+            default: "Dataset",
+            readonly:true
+            
+          },
+        },
+      ],
+    },
+
+    {
       key: "name",
       label: "Name",
       type: "text",

--- a/packages/ecc-client-elixir-ro-crate/src/components/about/about.ts
+++ b/packages/ecc-client-elixir-ro-crate/src/components/about/about.ts
@@ -120,29 +120,13 @@ export default class ECCClientRoCrateAbout extends LitElement {
     {
       key: "@type",
       label: "@type",
-      type: "array",
+      type: "text",
       fieldOptions: {
         tooltip: "The type of the entity.",
+        default: "Dataset",
+        readonly: true,
       },
-      arrayOptions: {
-        defaultInstances: 1,
-        max: 1,
-      },
-      children: [
-        {
-          key: "Type",
-          label: "Select",
-          type: "text",
-          fieldOptions: {
-            required: true,
-            default: "Dataset",
-            readonly:true
-            
-          },
-        },
-      ],
     },
-
     {
       key: "name",
       label: "Name",


### PR DESCRIPTION
## Description

Added readonly @type field in dataset entity.

Fixes #(issue)

## Checklist

<!-- Please go through the following checklist to ensure that your change is ready for review. -->

- [x] My code follows the [contributing guidelines][contributing] of this project.
- [x] I am aware that all my commits will be squashed into a single commit, using the PR title as the commit message.
- [ ] I have performed a self-review of my own code.
- [x] I have commented my code in hard-to-understand areas.
- [ ] I have updated the user-facing documentation to describe any new or changed behavior.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have not reduced the existing code coverage.

## Comments

<!-- If there are unchecked boxes in the list above, but you would still like your PR to be reviewed or considered for merging, please describe here why boxes were not checked. -->

[contributing]: CONTRIBUTING.md

## Summary by Sourcery

New Features:
- Introduce a readonly @type field in the dataset entity to specify the type of the entity.