### PR TITLE
Fix: Add tus data to ecc-utils-design-form on upload

### DIFF
--- a/.changeset/afraid-pugs-rush.md
+++ b/.changeset/afraid-pugs-rush.md
@@ -1,0 +1,5 @@
+---
+"@elixir-cloud/design": patch
+---
+
+return data from tus upload on ecc-utils-design-form

--- a/packages/ecc-utils-design/src/components/form/form.ts
+++ b/packages/ecc-utils-design/src/components/form/form.ts
@@ -563,6 +563,9 @@ export default class EccUtilsDesignForm extends LitElement {
     if (field.type === "array") {
       return this.renderArrayTemplate(field, newPath);
     }
+    if (field.type === "switch") {
+      return this.renderSwitchTemplate(field, newPath);
+    }
 
     if (field.fieldOptions?.required) {
       if (
@@ -570,10 +573,9 @@ export default class EccUtilsDesignForm extends LitElement {
         !this.requiredButEmpty.includes(field.key)
       ) {
         // add to requiredButEmpty
-
-        // eslint-disable-next-line no-empty
-        if (!this.hasUpdated && field.fieldOptions.default) {
-        } else this.requiredButEmpty.push(field.key);
+        if (this.hasUpdated || !field.fieldOptions.default) {
+          this.requiredButEmpty.push(field.key);
+        }
       } else if (_.get(this.form, newPath)) {
         // remove from requiredButEmpty
         this.requiredButEmpty = this.requiredButEmpty.filter(
@@ -582,9 +584,6 @@ export default class EccUtilsDesignForm extends LitElement {
       }
     }
 
-    if (field.type === "switch") {
-      return this.renderSwitchTemplate(field, newPath);
-    }
     return this.renderInputTemplate(field, newPath);
   }
 

--- a/packages/ecc-utils-design/src/components/form/form.ts
+++ b/packages/ecc-utils-design/src/components/form/form.ts
@@ -164,12 +164,12 @@ export default class EccUtilsDesignForm extends LitElement {
   private handleTusFileUpload = async (
     e: Event,
     field: Field
-  ): Promise<void> => {
+  ): Promise<Record<string, string> | null> => {
     const file = (e.target as HTMLInputElement).files?.[0];
 
     if (!file) {
       console.error("No file selected for upload.");
-      return;
+      return null;
     }
 
     try {
@@ -194,11 +194,20 @@ export default class EccUtilsDesignForm extends LitElement {
           this.requestUpdate();
         },
         onSuccess: () => {
+          const data: any = {
+            url: upload.url,
+            file,
+            name: "",
+          };
+
           if ("name" in upload.file) {
             console.log("Download %s from %s", upload.file.name, upload.url);
+            data.name = upload.file.name;
           } else {
             console.log("Download file from %s", upload.url);
           }
+
+          return data;
         },
       });
 
@@ -211,6 +220,8 @@ export default class EccUtilsDesignForm extends LitElement {
     } catch (error) {
       console.error("An error occurred while initializing the upload:", error);
     }
+
+    return null;
   };
 
   renderInputTemplate(field: Field, path: string): TemplateResult {
@@ -248,7 +259,12 @@ export default class EccUtilsDesignForm extends LitElement {
                   class="file-input"
                   ?disabled=${field.fieldOptions?.readonly}
                   @change=${async (e: Event) => {
-                    await this.handleTusFileUpload(e, field);
+                    const data = await this.handleTusFileUpload(e, field);
+
+                    if (data) {
+                      _.set(this.form, path, data);
+                      this.alertFieldChange(field.key, data);
+                    }
                   }}
                 />
                 <div class="progress-bar-container">

--- a/packages/ecc-utils-design/src/components/form/form.ts
+++ b/packages/ecc-utils-design/src/components/form/form.ts
@@ -548,9 +548,24 @@ export default class EccUtilsDesignForm extends LitElement {
       return this.renderArrayTemplate(field, newPath);
     }
 
-    if (field.fieldOptions?.required && !_.get(this.form, newPath)) {
-      this.requiredButEmpty.push(field.key);
+    if (field.fieldOptions?.required) {
+      if (
+        !_.get(this.form, newPath) &&
+        !this.requiredButEmpty.includes(field.key)
+      ) {
+        // add to requiredButEmpty
+
+        // eslint-disable-next-line no-empty
+        if (!this.hasUpdated && field.fieldOptions.default) {
+        } else this.requiredButEmpty.push(field.key);
+      } else if (_.get(this.form, newPath)) {
+        // remove from requiredButEmpty
+        this.requiredButEmpty = this.requiredButEmpty.filter(
+          (key) => key !== field.key
+        );
+      }
     }
+
     if (field.type === "switch") {
       return this.renderSwitchTemplate(field, newPath);
     }
@@ -648,7 +663,6 @@ export default class EccUtilsDesignForm extends LitElement {
   }
 
   render() {
-    this.requiredButEmpty = [];
     if (!this.fields || this.fields.length === 0) {
       throw new Error("Fields is required & should not be empty array");
     }


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change and the relevant issue(s) it resolves, if any (otherwise delete that line). -->

Fixes #387 

## Checklist

<!-- Please go through the following checklist to ensure that your change is ready for review. -->

- [ ] My code follows the [contributing guidelines][contributing] of this project.
- [ ] I am aware that all my commits will be squashed into a single commit, using the PR title as the commit message.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have updated the user-facing documentation to describe any new or changed behavior.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have not reduced the existing code coverage.

## Comments

<!-- If there are unchecked boxes in the list above, but you would still like your PR to be reviewed or considered for merging, please describe here why boxes were not checked. -->

[contributing]: CONTRIBUTING.md

## Summary by Sourcery

Fix the TUS file upload handling in the ecc-utils-design-form component to return upload data and update form state accordingly. Enhance the management of required fields and document the changes with a new changeset file.

Bug Fixes:
- Fix the return value of the handleTusFileUpload function to return upload data instead of void.

Enhancements:
- Update the form handling logic to store and alert field changes when TUS upload data is available.
- Improve the management of required fields by updating the requiredButEmpty list based on form data presence.

Chores:
- Add a changeset file to document the patch changes for the TUS upload data return feature.