### PR TITLE
fix: dockerfile nginx.root user unknown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ COPY --from=builder /app/apps/documentation/nginx.conf /etc/nginx/conf.d/default
 
 # support running as arbitrary user which belogs to the root group
 RUN chmod g+rwx /var/cache/nginx /var/run /var/log/nginx && \
-    chown nginx.root /var/cache/nginx /var/run /var/log/nginx && \
+    chown nginx:nginx /var/cache/nginx /var/run /var/log/nginx && \
     # comment user directive as master process is run as user in OpenShift anyhow
     sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf && \
     # Make /etc/nginx/html/ available to use


### PR DESCRIPTION
docker build was throwing following error:
```
 => ERROR [stage-3 4/4] RUN chmod g+rwx /var/cache/nginx /var/run /var/log/nginx &&     chown nginx.root /  0.3s
------
 > [stage-3 4/4] RUN chmod g+rwx /var/cache/nginx /var/run /var/log/nginx &&     chown nginx.root /var/cache/nginx /var/run /var/log/nginx &&     sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf &&     mkdir -p /etc/nginx/html/ && chmod 777 /etc/nginx/html/:
0.253 chown: unknown user nginx.root
------
Dockerfile:44
--------------------
  43 |     # support running as arbitrary user which belogs to the root group
  44 | >>> RUN chmod g+rwx /var/cache/nginx /var/run /var/log/nginx && \
  45 | >>>     chown nginx.root /var/cache/nginx /var/run /var/log/nginx && \
  46 | >>>     # comment user directive as master process is run as user in OpenShift anyhow
  47 | >>>     sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf && \
  48 | >>>     # Make /etc/nginx/html/ available to use
  49 | >>>     mkdir -p /etc/nginx/html/ && chmod 777 /etc/nginx/html/
  50 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c chmod g+rwx /var/cache/nginx /var/run /var/log/nginx &&     chown nginx.root /var/cache/nginx /var/run /var/log/nginx &&     sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf &&     mkdir -p /etc/nginx/html/ && chmod 777 /etc/nginx/html/" did not complete successfully: exit code: 1
exit status 1
```

